### PR TITLE
Update EKS version to 1.22 to simplify the deployment process using in-tree storageclass

### DIFF
--- a/content/3_launch_eks/31_provision_eks.md
+++ b/content/3_launch_eks/31_provision_eks.md
@@ -47,7 +47,7 @@ kind: ClusterConfig
 metadata:
   name: kubecost-workshop-eksctl
   region: ${AWS_REGION}
-  version: "1.23"
+  version: "1.22"
 
 availabilityZones: ["${AZS[0]}", "${AZS[1]}", "${AZS[2]}"]
 

--- a/content/3_launch_eks/31_provision_eks.md
+++ b/content/3_launch_eks/31_provision_eks.md
@@ -33,7 +33,7 @@ If you do see the correct role, proceed to next step to create an EKS cluster.
 ### Create an EKS cluster
 
 {{% notice warning %}}
-`eksctl` version must be 0.58.0 or above to deploy EKS 1.21, [click here](../212_prerequisites) to get the latest version.
+`eksctl` version must be 0.58.0 or above to deploy EKS 1.22, [click here](../212_prerequisites) to get the latest version.
 {{% /notice %}}
 
 Create an eksctl deployment file (kubecost-workshop.yaml) use in creating your cluster using the following syntax:

--- a/content/3_launch_eks/33_ingress_controller_alb.md
+++ b/content/3_launch_eks/33_ingress_controller_alb.md
@@ -53,7 +53,7 @@ eksctl utils associate-iam-oidc-provider \
 Learn more about [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) in the Amazon EKS documentation.
 {{% /notice %}}
 
-#### Create an IAM policy called
+#### Create an IAM policy
 
 Create a policy called **AWSLoadBalancerControllerIAMPolicy**
 

--- a/content/3_launch_eks/34_ebs_csi_driver.md
+++ b/content/3_launch_eks/34_ebs_csi_driver.md
@@ -1,0 +1,35 @@
+---
+title: "Deploy Amazon EBS CSI driver"
+chapter: false
+weight: 34
+---
+
+### Deploy the Amazon EBS CSI Driver
+
+{{% notice note %}}
+The [Amazon Elastic Block Store (Amazon EBS) Container Storage Interface (CSI) driver](https://www.eksworkshop.com/beginner/170_statefulset/ebs_csi_driver/#:~:text=Amazon%20Elastic%20Block%20Store%20(Amazon%20EBS)%20Container%20Storage%20Interface%20(CSI)%20driver) provides a [CSI interface](https://www.eksworkshop.com/beginner/170_statefulset/ebs_csi_driver/#:~:text=The%20Container%20Storage%20Interface) that allows Amazon Elastic Kubernetes Service (Amazon EKS) clusters to manage the lifecycle of Amazon EBS volumes for persistent volumes. This step is required if your Amazon EKS cluster version is 1.23 and above.
+{{% /notice %}}
+
+#### Create a IAM role and ServiceAccount
+
+```bash
+eksctl create iamserviceaccount \
+    --name ebs-csi-controller-sa \
+    --namespace kube-system \
+    --cluster kubecost-workshop-eksctl \
+    --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy \
+    --override-existing-serviceaccounts \
+    --approve \
+    --role-only \
+    --role-name AmazonEKS_EBS_CSI_DriverRole
+export SERVICE_ACCOUNT_ROLE_ARN=$(aws iam get-role --role-name AmazonEKS_EBS_CSI_DriverRole | jq -r '.Role.Arn')
+```
+
+#### Deploy the Amazon EBS CSI Driver using Amazon EKS-addon
+
+The Amazon EBS CSI Driver will deploy from the Amazon EKS-Addon
+
+```bash
+eksctl create addon --name aws-ebs-csi-driver --cluster $CLUSTER_NAME \
+    --service-account-role-arn $SERVICE_ACCOUNT_ROLE_ARN --force
+```


### PR DESCRIPTION
Signed-off-by: Linh Lam <linh@kubecost.com>

*Issue #, if available:*

*Description of changes:*
Update EKS version to 1.22 to simplify the deployment process using in-tree storageclass. For version 1.23+, the EBS CSI driver must be installed manually by customer before deploying any applications that need persistent storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
