### PR TITLE
Update 24_clistools.md - fix kubectl install cli to use AMD64 binary

### DIFF
--- a/content/2_setup/24_clistools.md
+++ b/content/2_setup/24_clistools.md
@@ -17,7 +17,7 @@ for the download links.](https://docs.aws.amazon.com/eks/latest/userguide/gettin
 
 ```bash
 sudo curl --silent --location -o /usr/local/bin/kubectl \
-   https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/arm64/kubectl
+   https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/amd64/kubectl
 
 sudo chmod +x /usr/local/bin/kubectl
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update 24_clistools.md - fix kubectl install cli to use AMD64 binary instead of ARM64 binary

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
