### PR TITLE
bump version of Kubecost

### DIFF
--- a/content/4_deploy_kubecost/41_deployingkubecost.en.md
+++ b/content/4_deploy_kubecost/41_deployingkubecost.en.md
@@ -19,7 +19,7 @@ Kubecost provides real-time cost visibility and insights for teams using Kuberne
 In your environment, run the following command from your terminal to install Kubecost on your existing Amazon EKS cluster:
 
 ```bash
-export VERSION="1.103.2"
+export VERSION="1.106.0"
 helm upgrade -i kubecost \
 oci://public.ecr.aws/kubecost/cost-analyzer --version="$VERSION" \
 --namespace kubecost --create-namespace \


### PR DESCRIPTION
Signed-off-by: Chip Zoller <chipzoller@gmail.com>

Bumps default version of Kubecost to 1.106.0.